### PR TITLE
Shuffle correction & Cascading master working well

### DIFF
--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -223,7 +223,6 @@ uint32_t gttcan_get_time_to_next_transmission(uint16_t current_slot_id, gttcan_t
     }
 
     gttcan->slot_duration += gttcan->slot_duration_offset / 50;
-    gttcan->slot_duration_offset = 0;
 
     uint32_t time = (uint32_t)number_of_slots_to_next * gttcan->slot_duration;
 

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -222,7 +222,10 @@ uint32_t gttcan_get_time_to_next_transmission(uint16_t current_slot_id, gttcan_t
         gttcan->slot_duration_offset = 0;
     }
 
-    uint32_t time = (uint32_t)number_of_slots_to_next * gttcan->slot_duration + gttcan->slot_duration_offset / 50;
+    gttcan->slot_duration += gttcan->slot_duration_offset / 50;
+    gttcan->slot_duration_offset = 0;
+
+    uint32_t time = (uint32_t)number_of_slots_to_next * gttcan->slot_duration;
 
     if (time > gttcan->timing_offset)
     {

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -222,7 +222,7 @@ uint32_t gttcan_get_time_to_next_transmission(uint16_t current_slot_id, gttcan_t
         gttcan->slot_duration_offset = 0;
     }
 
-    gttcan->slot_duration += gttcan->slot_duration_offset / 50;
+    gttcan->slot_duration += gttcan->slot_duration_offset;
 
     uint32_t time = (uint32_t)number_of_slots_to_next * gttcan->slot_duration;
 

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -68,6 +68,7 @@ void gttcan_start(
     uint32_t start_up_wait_time = ((gttcan->global_schedule_length + (gttcan->node_id * DEFAULT_STARTUP_PAUSE_SLOTS)) * gttcan->slot_duration);
     gttcan->local_schedule_index = 0;
     gttcan->isTimeMaster = false;
+    gttcan->last_lowest_seen_node_id = gttcan->node_id;
     gttcan->set_timer_int_callback_fp(start_up_wait_time);
 }
 
@@ -166,7 +167,7 @@ void gttcan_process_frame(gttcan_t *gttcan, uint32_t can_frame_id, uint64_t data
     if (data_id == REFERENCE_FRAME_DATA_ID)
     {
         gttcan->reached_end_of_my_schedule_prematurely = false;
-        if(gttcan->local_schedule_index == 0 && !gttcan->isTimeMaster){
+        if(slot_id < 5 && !gttcan->isTimeMaster){
             if (gttcan->slot_duration_offset > 0){
                 gttcan->slot_duration++;
             }

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -253,7 +253,6 @@ void gttcan_get_local_schedule(gttcan_t *gttcan, global_schedule_ptr_t global_sc
     uint16_t local_schedule_index = 0;
     for (int i = 0; i < gttcan->global_schedule_length; i++)
     {
-        bool add_to_local = false;
         // Is this my own frame or reference frames?
         if (global_schedule_ptr[i].node_id == gttcan->node_id || global_schedule_ptr[i].data_id == REFERENCE_FRAME_DATA_ID)
         {

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -234,7 +234,7 @@ void gttcan_process_frame(gttcan_t *gttcan, uint32_t can_frame_id, uint64_t data
     }
     // future per frame clock correction functionalities maybe
 
-    uint8_t rx_node_id;
+    uint8_t rx_node_id = 0; // Default value indicating no match found
     for(int i = 0; i < gttcan->global_schedule_length; i++){
         if(gttcan->global_schedule_ptr[i].slot_id == slot_id){
             rx_node_id = gttcan->global_schedule_ptr[i].node_id;

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -167,7 +167,7 @@ void gttcan_process_frame(gttcan_t *gttcan, uint32_t can_frame_id, uint64_t data
     if (data_id == REFERENCE_FRAME_DATA_ID)
     {
         gttcan->reached_end_of_my_schedule_prematurely = false;
-        if(slot_id < 5 && !gttcan->isTimeMaster){
+        if(slot_id == 0 && !gttcan->isTimeMaster){
             if (gttcan->slot_duration_offset > 0){
                 gttcan->slot_duration++;
             }

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -37,6 +37,8 @@ void gttcan_init(
     // gttcan->last_reference_frame_hardware_time = 0;
     gttcan->last_schedule_transmission_time = 0;
     gttcan->is_initialised = true;
+
+    gttcan->slot_duration_offset=0;
 }
 
 // Transmit frame (blink a blinky LED )
@@ -217,10 +219,6 @@ uint32_t gttcan_get_time_to_next_transmission(uint16_t current_slot_id, gttcan_t
 {
     uint16_t next_slot_id = gttcan->local_schedule[gttcan->local_schedule_index].slot_id;
     uint16_t number_of_slots_to_next = gttcan_get_number_of_slots_to_next(current_slot_id, next_slot_id, gttcan->global_schedule_length);
-
-    if ((gttcan->slot_duration_offset/50) < -1*gttcan->slot_duration || (gttcan->slot_duration_offset/50) > gttcan->slot_duration ){
-        gttcan->slot_duration_offset = 0;
-    }
 
     gttcan->slot_duration += gttcan->slot_duration_offset;
 

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -218,7 +218,7 @@ uint32_t gttcan_get_time_to_next_transmission(uint16_t current_slot_id, gttcan_t
     uint16_t next_slot_id = gttcan->local_schedule[gttcan->local_schedule_index].slot_id;
     uint16_t number_of_slots_to_next = gttcan_get_number_of_slots_to_next(current_slot_id, next_slot_id, gttcan->global_schedule_length);
 
-    if (gttcan->slot_duration_offset < -1*gttcan->slot_duration || gttcan->slot_duration_offset > gttcan->slot_duration ){
+    if ((gttcan->slot_duration_offset/50) < -1*gttcan->slot_duration || (gttcan->slot_duration_offset/50) > gttcan->slot_duration ){
         gttcan->slot_duration_offset = 0;
     }
 

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -100,12 +100,12 @@ void gttcan_process_frame(gttcan_t *gttcan, uint32_t can_frame_id, uint64_t data
     if (gttcan->local_schedule_index > 0 && slot_id > gttcan->local_schedule[gttcan->local_schedule_index].slot_id)
     {
         // If received frame is greater than the next one I want to send, and I haven't wrapped, then I am slow
-        gttcan->slot_duration_offset--; // SPEED ME UP
+        gttcan->slot_duration--; // SPEED ME UP
     }
     if (gttcan->local_schedule_index > 0 && slot_id != 0 && slot_id < gttcan->local_schedule[gttcan->local_schedule_index - 1].slot_id)
     {
         // If received frame is less than one I have already transmitted (and I've transmitted already this schedule)
-        gttcan->slot_duration_offset++; // SLOW ME DOWN, I TRANSMITTED BEFORE SOMEONE ELSE HAD THE CHANCE, WHICH CAN'T BE POSSIBLE IF I AM AT ZERO
+        gttcan->slot_duration++; // SLOW ME DOWN, I TRANSMITTED BEFORE SOMEONE ELSE HAD THE CHANCE, WHICH CAN'T BE POSSIBLE IF I AM AT ZERO
     }
 
     if (!gttcan->isActive && slot_id == 0)
@@ -142,11 +142,11 @@ void gttcan_process_frame(gttcan_t *gttcan, uint32_t can_frame_id, uint64_t data
                 // Found the next slot, position the index at the previous entry
                 if (gttcan->local_schedule_index < i)
                 {
-                    gttcan->slot_duration_offset--; // NEEDS A SPEEDUP, because I didn't get to transmit a frame
+                    gttcan->slot_duration--; // NEEDS A SPEEDUP, because I didn't get to transmit a frame
                 }
                 if (i == 0 && gttcan->local_schedule_index)
                 {
-                    gttcan->slot_duration_offset--; // Needs a speedup, as I never got to transmit my final frame
+                    gttcan->slot_duration--; // Needs a speedup, as I never got to transmit my final frame
                 }
                 gttcan->local_schedule_index = i;
 
@@ -160,7 +160,7 @@ void gttcan_process_frame(gttcan_t *gttcan, uint32_t can_frame_id, uint64_t data
             // No slot is greater than the reference slot
             if (gttcan->local_schedule_index != 0)
             {
-                gttcan->slot_duration_offset--; // Needs a speedup, as I never got to transmit my final frame
+                gttcan->slot_duration--; // Needs a speedup, as I never got to transmit my final frame
             }
             gttcan->local_schedule_index = 0;
         }
@@ -220,7 +220,6 @@ uint32_t gttcan_get_time_to_next_transmission(uint16_t current_slot_id, gttcan_t
     uint16_t next_slot_id = gttcan->local_schedule[gttcan->local_schedule_index].slot_id;
     uint16_t number_of_slots_to_next = gttcan_get_number_of_slots_to_next(current_slot_id, next_slot_id, gttcan->global_schedule_length);
 
-    gttcan->slot_duration += gttcan->slot_duration_offset;
 
     uint32_t time = (uint32_t)number_of_slots_to_next * gttcan->slot_duration;
 

--- a/src/gttcan.c
+++ b/src/gttcan.c
@@ -112,15 +112,6 @@ void gttcan_transmit_next_frame(gttcan_t *gttcan)
         gttcan->transmit_frame_callback_fp(ext_frame_header, ((uint64_t)gttcan->slot_duration << 16) | gttcan->node_id);
     }
 
-    if(gttcan->local_schedule_index == 0 && !gttcan->isTimeMaster){
-        if (gttcan->slot_duration_offset > 0){
-            gttcan->slot_duration++;
-        }
-        if (gttcan->slot_duration_offset < 0) {
-            gttcan->slot_duration--;
-        }
-    }
-
     if (gttcan->node_id < gttcan->current_lowest_seen_node_id || gttcan->current_lowest_seen_node_id == 0){
         gttcan->current_lowest_seen_node_id = gttcan->node_id;
     }
@@ -175,6 +166,14 @@ void gttcan_process_frame(gttcan_t *gttcan, uint32_t can_frame_id, uint64_t data
     if (data_id == REFERENCE_FRAME_DATA_ID)
     {
         gttcan->reached_end_of_my_schedule_prematurely = false;
+        if(gttcan->local_schedule_index == 0 && !gttcan->isTimeMaster){
+            if (gttcan->slot_duration_offset > 0){
+                gttcan->slot_duration++;
+            }
+            if (gttcan->slot_duration_offset < 0) {
+                gttcan->slot_duration--;
+            }
+        }
         gttcan->slot_duration_offset = 0;
         int32_t time_difference = 0;
 

--- a/src/include/gttcan.h
+++ b/src/include/gttcan.h
@@ -78,6 +78,9 @@ typedef struct gttcan_tag
 
     // Timing related
     uint32_t last_schedule_transmission_time;
+    bool has_adjusted_slots_this_round;
+
+    bool reached_end_of_my_schedule_prematurely;
 
 } gttcan_t;
 

--- a/src/include/gttcan.h
+++ b/src/include/gttcan.h
@@ -67,6 +67,7 @@ typedef struct gttcan_tag
     uint16_t local_schedule_index;
     uint32_t slot_duration;
     uint32_t timing_offset;
+    int slot_duration_offset;
 
     // Callback functions
     transmit_frame_callback_fp_t transmit_frame_callback_fp;

--- a/src/include/gttcan.h
+++ b/src/include/gttcan.h
@@ -61,7 +61,7 @@ typedef struct gttcan_tag
     bool is_initialised;
     // Schedule related
     local_schedule_entry_t local_schedule[GTTCAN_MAX_LOCAL_SCHEDULE_LENGTH];
-    // global_schedule_ptr_t global_schedule_ptr; //could keep a pointer in the future if we need to use global_schedule, i.e. fault tolerance or if global_schedule needs to be dynamically changed?
+    global_schedule_ptr_t global_schedule_ptr; //could keep a pointer in the future if we need to use global_schedule, i.e. fault tolerance or if global_schedule needs to be dynamically changed?
     uint16_t global_schedule_length;
     uint16_t local_schedule_length;
     uint16_t local_schedule_index;
@@ -81,6 +81,13 @@ typedef struct gttcan_tag
     bool has_adjusted_slots_this_round;
 
     bool reached_end_of_my_schedule_prematurely;
+
+
+    // Cascading master
+    uint8_t last_lowest_seen_node_id;
+    uint8_t current_lowest_seen_node_id;
+    bool isTimeMaster;
+    bool has_received;
 
 } gttcan_t;
 

--- a/src/include/gttcan.h
+++ b/src/include/gttcan.h
@@ -7,7 +7,7 @@
 
 /* GTTCAN_MAX_LOCAL_SCHEDULE_LENGTH must fit into a uint8_t, so be less than or equal to 255 */ // is this a necessary restriction?
 #ifndef GTTCAN_MAX_LOCAL_SCHEDULE_LENGTH
-#define GTTCAN_MAX_LOCAL_SCHEDULE_LENGTH 256
+#define GTTCAN_MAX_LOCAL_SCHEDULE_LENGTH 512
 #endif
 
 /* REQUIREMENT
@@ -28,6 +28,7 @@
 
 #define REFERENCE_FRAME_DATA_ID 0 // ifndef?
 #define GENERIC_DATA_ID 1         // ifndef?
+#define DEFAULT_STARTUP_PAUSE_SLOTS 2
 
 // Consider making this into masked 29 bit CAN Frame IDs from start, but this struct is more readable
 // I think NUM_SLOT_ID_BITS and NUM_DATA_ID_BITS could be up to the end user, but is there any point???
@@ -37,7 +38,7 @@ typedef struct local_schedule_entry_tag
     uint16_t data_id;     // could be as large as the size of the whiteboard //TODO:?
 } local_schedule_entry_t; // THIS SHOULD BE USED when it needs to be used in a user defined function
 
-#define MAX_GLOBAL_SCHEDULE_LENGTH 256 // check if number is ok and ifndef
+#define MAX_GLOBAL_SCHEDULE_LENGTH 512 // check if number is ok and ifndef
 
 typedef struct global_schedule_entry
 {


### PR DESCRIPTION
Shuffle correction - slot duration is self adjusting based on whether a node receives an 'early' or 'late' frame relative to its own schedule from the bus. There must be a node with a stable unchanging slot_duration, which is always the node that is the time master which does not change, and the other nodes will sync to this.

Cascading master - the master and other nodes can be removed from the network and then another node will become the master, and send reference frames in its place. When the lower node_id node comes back online, it will regain status as the master.